### PR TITLE
fix: prevent calling postMessage on null value

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -13,10 +13,12 @@ export class ObserverIframe {
   }
 
   update (type, payload) {
-    this.el && this.el.contentWindow.postMessage({
-      type,
-      payload
-    }, this.origin)
+    if (this.el && this.el.contentWindow) {
+      this.el.contentWindow.postMessage({
+        type,
+        payload
+      }, this.origin)
+    }
   }
 }
 


### PR DESCRIPTION
When re-mounting an Iframe `this.el.contentWindow` is initially set to null which breaks the sync. 

Adding a conditional ensures `postMessage` is only called when `contentWindow` exists